### PR TITLE
mpdecimal v4.0.1

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,14 @@
 @ECHO off
 
 set dbg=0
-set machine=x64
+
+REM Detect target architecture - ARM64 needs ansi64 (pure C, no x64 MASM assembly)
+REM Check target_platform first (conda-build), then fall back to processor arch
+if "%target_platform%"=="win-arm64" (
+    set machine=ansi64
+) else (
+    set machine=x64
+)
 
 mkdir %LIBRARY_BIN%
 mkdir %LIBRARY_LIB%

--- a/recipe/fix-dll-name.diff
+++ b/recipe/fix-dll-name.diff
@@ -1,21 +1,21 @@
 diff --git a/libmpdec++/Makefile.vc b/libmpdec++/Makefile.vc
-index 5985c33..68b03b1 100644
+index 33a4126..68b03b1 100644
 --- a/libmpdec++/Makefile.vc
 +++ b/libmpdec++/Makefile.vc
 @@ -5,13 +5,13 @@
  
  SRCDIR = ..\libmpdec
  
--LIBSTATIC = libmpdec-4.0.0.lib
--LIBIMPORT = libmpdec-4.0.0.dll.lib
--LIBSHARED = libmpdec-4.0.0.dll
+-LIBSTATIC = libmpdec-4.0.1.lib
+-LIBIMPORT = libmpdec-4.0.1.dll.lib
+-LIBSHARED = libmpdec-4.0.1.dll
 +LIBSTATIC = libmpdec-4.lib
 +LIBIMPORT = libmpdec-4.dll.lib
 +LIBSHARED = libmpdec-4.dll
  
--LIBSTATIC_CXX = libmpdec++-4.0.0.lib
--LIBIMPORT_CXX = libmpdec++-4.0.0.dll.lib
--LIBSHARED_CXX = libmpdec++-4.0.0.dll
+-LIBSTATIC_CXX = libmpdec++-4.0.1.lib
+-LIBIMPORT_CXX = libmpdec++-4.0.1.dll.lib
+-LIBSHARED_CXX = libmpdec++-4.0.1.dll
 +LIBSTATIC_CXX = libmpdec++-4.lib
 +LIBIMPORT_CXX = libmpdec++-4.dll.lib
 +LIBSHARED_CXX = libmpdec++-4.dll
@@ -23,16 +23,16 @@ index 5985c33..68b03b1 100644
  !if "$(DEBUG)" == "1"
  OPT = /MTd /Od /Zi /EHsc
 diff --git a/libmpdec/Makefile.vc b/libmpdec/Makefile.vc
-index 7f72a4b..8f7e618 100644
+index 48bead3..8f7e618 100644
 --- a/libmpdec/Makefile.vc
 +++ b/libmpdec/Makefile.vc
 @@ -3,9 +3,9 @@
  #                 Visual C (nmake) Makefile for libmpdec
  # ======================================================================
  
--LIBSTATIC = libmpdec-4.0.0.lib
--LIBIMPORT = libmpdec-4.0.0.dll.lib
--LIBSHARED = libmpdec-4.0.0.dll
+-LIBSTATIC = libmpdec-4.0.1.lib
+-LIBIMPORT = libmpdec-4.0.1.dll.lib
+-LIBSHARED = libmpdec-4.0.1.dll
 +LIBSTATIC = libmpdec-4.lib
 +LIBIMPORT = libmpdec-4.dll.lib
 +LIBSHARED = libmpdec-4.dll

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.0.0" %}
+{% set version = "4.0.1" %}
 
 package:
   name: mpdecimal
@@ -6,24 +6,21 @@ package:
 
 source:
   url: https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-{{ version }}.tar.gz
-  sha256: 942445c3245b22730fd41a67a7c5c231d11cb1b9936b9c0f76334fb7d0b4468c
+  sha256: 96d33abb4bb0070c7be0fed4246cd38416188325f820468214471938545b1ac8
   patches:
     - fix-dll-name.diff
 
 build:
   number: 0
-  missing_dso_whitelist:     # [s390x]
-    - "$RPATH/ld64.so.1"     # [s390x]
 
 requirements:
   build:
+    - {{ stdlib('c')}}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - make                   # [unix]
     - wget                   # [unix]
     - unzip                  # [unix]
-    - m2-patch               # [win]
-    - patch                  # [not win]
   host:
   run:
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
 
 requirements:
   build:
-    - {{ stdlib('c')}}
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - make                   # [unix]
@@ -32,6 +32,7 @@ outputs:
       - Library/bin/libmpdec-*.dll  # [win]
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
     test:
       commands:
@@ -47,6 +48,7 @@ outputs:
       - Library/bin/libmpdec++-*.dll  # [win]
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('cxx') }}
       host:
         - {{ pin_subpackage("libmpdec", exact=True) }}
@@ -71,7 +73,12 @@ outputs:
       - Library/lib/mpdec.lib        # [win]
       - Library/include/mpdecimal.h  # [win]
     requirements:
-      - {{ pin_subpackage("libmpdec", exact=True) }}
+      build:
+        - {{ stdlib('c') }}
+      host:
+        - {{ pin_subpackage("libmpdec", exact=True) }}
+      run:
+        - {{ pin_subpackage("libmpdec", exact=True) }}
     test:
       commands:
         - test -f ${PREFIX}/lib/libmpdec.so            # [linux]
@@ -90,8 +97,14 @@ outputs:
       - Library/lib/mpdec++.lib      # [win]
       - Library/include/decimal.hh   # [win]
     requirements:
-      - {{ pin_subpackage("libmpdecxx", exact=True) }}
-      - {{ pin_subpackage("libmpdec-devel", exact=True) }}
+      build:
+        - {{ stdlib('c') }}
+      host:
+        - {{ pin_subpackage("libmpdec-devel", exact=True) }}
+        - {{ pin_subpackage("libmpdecxx", exact=True) }}
+      run:
+        - {{ pin_subpackage("libmpdec-devel", exact=True) }}
+        - {{ pin_subpackage("libmpdecxx", exact=True) }}
     test:
       commands:
         - test -f ${PREFIX}/lib/libmpdec++.so            # [linux]


### PR DESCRIPTION
mpdecimal v4.0.1

**Destination channel:** defaults

### Links

- [PKG-15352](https://anaconda.atlassian.net/browse/PKG-15352) 
- [Upstream repository](https://www.bytereef.org/mpdecimal/download.html)
- [Upstream changelog/diff](https://www.bytereef.org/mpdecimal/changelog.html)


### Explanation of changes:

- Bump version and SHA
- Adds fix for win-arm64
- Modernize recipe


[PKG-15352]: https://anaconda.atlassian.net/browse/PKG-15352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ